### PR TITLE
Add sample .env and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Sample configuration for connecting to your one.com email account
+# Copy this file to `.env` and fill in your real credentials.
+
+# Display name to show when sending emails (optional)
+ONE_NAME="Your Name"
+
+# The full email address of your one.com account
+ONE_EMAIL=your@email.com
+
+# Username for authentication (usually the same as your email)
+ONE_USERNAME=$ONE_EMAIL
+
+# Password for your one.com email account
+ONE_PASSWORD=your_password
+
+# Incoming mail server settings
+ONE_IMAP_SERVER=imap.one.com
+ONE_IMAP_PORT=993
+
+# Outgoing mail server settings
+ONE_SMTP_SERVER=send.one.com
+ONE_SMTP_PORT=587
+
+# IMAP path prefix for one.com
+ONE_IMAP_PATH_PREFIX=INBOX

--- a/tests/test_env_example.py
+++ b/tests/test_env_example.py
@@ -1,0 +1,22 @@
+import os
+import re
+import pytest
+
+ENV_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env.example')
+
+def test_env_example_exists():
+    assert os.path.exists(ENV_PATH), "'.env.example' file is missing"
+
+def test_env_example_contents():
+    with open(ENV_PATH, 'r') as f:
+        content = f.read()
+    # expected keys
+    required_keys = [
+        'ONE_EMAIL',
+        'ONE_USERNAME',
+        'ONE_PASSWORD',
+        'ONE_IMAP_SERVER',
+        'ONE_SMTP_SERVER'
+    ]
+    for key in required_keys:
+        assert re.search(rf'^{key}=.*', content, re.MULTILINE), f"Missing {key} in .env.example"


### PR DESCRIPTION
## Summary
- add `.env.example` with example settings for one.com
- add tests verifying `.env.example` exists and contains required fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683d7d9a97c0832cb8d424b34adcab5f