### PR TITLE
Fix fetch_sent_emails failing if mailbox select fails

### DIFF
--- a/important_email2.py
+++ b/important_email2.py
@@ -145,7 +145,9 @@ def fetch_recent_sent_emails(days: int = 7):
     sent_emails = []
     with imaplib.IMAP4_SSL(server, port) as imap:
         imap.login(username, password)
-        imap.select(sent_folder)
+        status, _ = imap.select(sent_folder)
+        if status != "OK":
+            return []
         status, data = imap.search(None, f'(SINCE "{cutoff}")')
         if status != "OK":
             return []

--- a/tests/test_fetch_sent_emails_failure.py
+++ b/tests/test_fetch_sent_emails_failure.py
@@ -1,0 +1,33 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import important_email2
+import imaplib
+import pytest
+
+class FailSelectIMAP:
+    def __init__(self, server, port):
+        pass
+    def login(self, user, password):
+        pass
+    def select(self, mbox):
+        return ('NO', [b'Error'])
+    def search(self, charset, query):
+        raise imaplib.IMAP4.error("command SEARCH illegal in state AUTH")
+    def fetch(self, num, data):
+        return ('OK', [])
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+def fail_select_imap(server, port):
+    return FailSelectIMAP(server, port)
+
+def test_fetch_recent_sent_emails_handles_select_failure(monkeypatch):
+    monkeypatch.setattr(important_email2.imaplib, 'IMAP4_SSL', fail_select_imap)
+    monkeypatch.setenv('EMAIL_USER', 'user')
+    monkeypatch.setenv('EMAIL_PASSWORD', 'pass')
+    result = important_email2.fetch_recent_sent_emails(days=1)
+    assert result == []


### PR DESCRIPTION
## Summary
- ensure `fetch_recent_sent_emails` handles failure to select the Sent mailbox
- add regression test to confirm graceful handling of bad select

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683d8340ddd0832c9c9a40b13cd929b9