### PR TITLE
Implement email topic grouping and deletion workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ This project helps you reach **inbox zero**. It uses OpenAI models to scan your 
    ```bash
    python important_email2.py
    ```
-   Generates `needs_response_report.txt` with the messages that require your reply.
+   Generates `output/needs_response_report.json` with the messages that require your reply.
 2. **Categorize business opportunities**
    ```bash
    python send_mail2.py
    ```
-   Writes results to `categorized_emails.json` and an opportunity report.
+   Writes results to `output/categorized_emails.json` and an opportunity report.
 3. **Draft and send responses**
    ```bash
    python email_responder2.py
@@ -53,7 +53,7 @@ This project helps you reach **inbox zero**. It uses OpenAI models to scan your 
 
 - Run `pytest` to execute the unit tests.
 - Modify the scripts or create new modules as needed. The IMAP/SMTP functions already handle fetching and sending email (see `important_email2.py` and `send_mail2.py`). Environment variable names are the same ones used in `.env.example`.
-- Keep data files such as `needs_response_report.txt` and `categorized_emails.json` out of version control.
+- Keep data files such as those in the `output/` folder out of version control.
 
 ## 🙋 How to use (non‑technical overview)
 
@@ -70,10 +70,10 @@ This project helps you reach **inbox zero**. It uses OpenAI models to scan your 
 
 ## 📁 Output files
 
-- `needs_response_report.txt` – list of messages requiring a reply
-- `categorized_emails.json` – JSON export of analyzed emails
-- `opportunity_report.txt` – summary of good business leads
-- `response_history.json` – log of emails you have answered
+- `output/needs_response_report.json` – list of messages requiring a reply
+- `output/categorized_emails.json` – JSON export of analyzed emails
+- `output/opportunity_report.json` – summary of good business leads
+- `output/response_history.json` – log of emails you have answered
 
 ## 🛡️ Security
 

--- a/delete_emails.py
+++ b/delete_emails.py
@@ -1,0 +1,75 @@
+import os
+import json
+import imaplib
+from datetime import datetime
+from dotenv import load_dotenv
+
+OUTPUT_DIR = "output"
+TO_DELETE_FILE = os.path.join(OUTPUT_DIR, "to_delete.json")
+LOG_FILE = os.path.join(OUTPUT_DIR, "delete_emails.log")
+
+load_dotenv(override=True)
+
+
+def load_delete_tasks(tasks_file=TO_DELETE_FILE):
+    try:
+        with open(tasks_file, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return []
+
+
+def save_delete_tasks(tasks, tasks_file=TO_DELETE_FILE):
+    os.makedirs(os.path.dirname(tasks_file), exist_ok=True)
+    with open(tasks_file, "w", encoding="utf-8") as f:
+        json.dump(tasks, f, indent=2)
+
+
+def log(message):
+    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(f"{datetime.now().isoformat()} - {message}\n")
+    print(message)
+
+
+def delete_email(task):
+    username = os.getenv("EMAIL_USER")
+    password = os.getenv("EMAIL_PASSWORD")
+    server = os.getenv("IMAP_SERVER", "imap.gmail.com")
+    port = int(os.getenv("IMAP_PORT", "993"))
+
+    if not username or not password:
+        raise ValueError("EMAIL_USER and EMAIL_PASSWORD must be set")
+
+    with imaplib.IMAP4_SSL(server, port) as imap:
+        imap.login(username, password)
+        imap.select("INBOX")
+        status, data = imap.search(None, f'(HEADER Subject "{task["subject"]}")')
+        if status != "OK":
+            return False
+        for num in data[0].split():
+            imap.store(num, "+FLAGS", "\\Deleted")
+        imap.expunge()
+    return True
+
+
+def process_deletions(tasks_file=TO_DELETE_FILE):
+    tasks = load_delete_tasks(tasks_file)
+    updated = False
+    for task in tasks:
+        if task.get("status") != "to delete":
+            continue
+        log(f"Deleting: {task['subject']}")
+        if delete_email(task):
+            task["status"] = "deleted"
+            task["deleted_at"] = datetime.now().isoformat()
+            updated = True
+            log(f"Deleted: {task['subject']}")
+        else:
+            log(f"Failed to delete: {task['subject']}")
+    if updated:
+        save_delete_tasks(tasks, tasks_file)
+
+
+if __name__ == "__main__":
+    process_deletions()

--- a/email_responder2.py
+++ b/email_responder2.py
@@ -1,6 +1,7 @@
 import os
 import json
 import re
+from datetime import datetime
 from openai import OpenAI
 from dotenv import load_dotenv
 from send_mail2 import send_email  # Importing the placeholder send_email function
@@ -9,48 +10,41 @@ from send_mail2 import send_email  # Importing the placeholder send_email functi
 load_dotenv(override=True)
 
 # File paths
-NEEDS_RESPONSE_REPORT = "needs_response_report.txt"
-RESPONSE_HISTORY_FILE = "response_history.json"
+OUTPUT_DIR = "output"
+NEEDS_RESPONSE_REPORT = os.path.join(OUTPUT_DIR, "needs_response_report.json")
+RESPONSE_HISTORY_FILE = os.path.join(OUTPUT_DIR, "response_history.json")
+LOG_FILE = os.path.join(OUTPUT_DIR, "email_responder2.log")
+
+
+def log(message):
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(f"{datetime.now().isoformat()} - {message}\n")
+    print(message)
 
 def extract_emails_from_report(report_path=NEEDS_RESPONSE_REPORT):
-    """Extract emails from the needs_response_report.txt file"""
+    """Extract emails from the needs_response_report.json file"""
     try:
         with open(report_path, "r", encoding="utf-8") as f:
-            content = f.read()
-        
-        # Split the report by the separator
-        email_sections = content.split("-" * 50)
-        
-        # Extract information from each section
+            data = json.load(f)
+
         emails = []
-        for section in email_sections:
-            if not section.strip():
-                continue
-            
-            # Extract key details using regex
-            subject_match = re.search(r"Subject: (.+?)$", section, re.MULTILINE)
-            from_match = re.search(r"From: (.+?)$", section, re.MULTILINE)
-            email_address_match = re.search(r"<(.+?)>", section)
-            preview_match = re.search(r"Preview: (.+?)$", section, re.MULTILINE | re.DOTALL)
-            already_responded = "ALREADY RESPONDED" in section
-            
-            if subject_match and from_match:
-                email_data = {
-                    "subject": subject_match.group(1).strip(),
-                    "from": from_match.group(1).strip(),
-                    "email_address": email_address_match.group(1).strip() if email_address_match else None,
-                    "preview": preview_match.group(1).strip() if preview_match else "No preview available",
-                    "already_responded": already_responded
-                }
-                emails.append(email_data)
-        
+        for item in data.get("emails", []):
+            address_match = re.search(r"<(.+?)>", item.get("from", ""))
+            emails.append({
+                "subject": item.get("subject", ""),
+                "from": item.get("from", ""),
+                "email_address": address_match.group(1) if address_match else None,
+                "preview": item.get("body", "")[:1000],
+                "already_responded": item.get("already_responded", False)
+            })
         return emails
     
     except FileNotFoundError:
-        print(f"Error: File {report_path} not found.")
+        log(f"Error: File {report_path} not found.")
         return []
     except Exception as e:
-        print(f"Error extracting emails from report: {e}")
+        log(f"Error extracting emails from report: {e}")
         return []
 
 def save_response_history(new_response):
@@ -73,10 +67,10 @@ def save_response_history(new_response):
         # Save back to file
         with open(RESPONSE_HISTORY_FILE, "w", encoding="utf-8") as f:
             json.dump(history, f, indent=2)
-            
+        log("Updated response history")
         return True
     except Exception as e:
-        print(f"Error saving response history: {e}")
+        log(f"Error saving response history: {e}")
         return False
 
 def generate_response(client, email_data, edit_instructions=None):
@@ -141,7 +135,7 @@ def generate_response(client, email_data, edit_instructions=None):
         return response.choices[0].message.content
     
     except Exception as e:
-        print(f"Error generating response: {e}")
+        log(f"Error generating response: {e}")
         return None
 
 def process_responses():
@@ -153,36 +147,35 @@ def process_responses():
     emails = extract_emails_from_report()
     
     if not emails:
-        print("No emails requiring response found in the report.")
+        log("No emails requiring response found in the report.")
         return
     
     # Count new emails (not already responded to)
     new_emails = [email for email in emails if not email['already_responded']]
     
-    print(f"Found {len(emails)} emails requiring response ({len(new_emails)} new, {len(emails) - len(new_emails)} already responded to).\n")
+    log(f"Found {len(emails)} emails requiring response ({len(new_emails)} new, {len(emails) - len(new_emails)} already responded to).")
     
     # Process each email
     for i, email_data in enumerate(emails, 1):
-        print("=" * 50)
-        print(f"Email {i}/{len(emails)}")
-        print(f"Subject: {email_data['subject']}")
-        print(f"From: {email_data['from']}")
+        log("=" * 50)
+        log(f"Email {i}/{len(emails)}")
+        log(f"Subject: {email_data['subject']}")
+        log(f"From: {email_data['from']}")
         
         if email_data['already_responded']:
-            print(f"STATUS: ✅ ALREADY RESPONDED")
+            log("STATUS: ✅ ALREADY RESPONDED")
             choice = input("\nThis email has already been responded to. Process anyway? (y/n): ").lower()
             if choice != 'y':
-                print("Skipping to next email...")
-                print()
+                log("Skipping to next email...")
                 continue
         
-        print("-" * 50)
+        log("-" * 50)
         
         # Generate a response
         draft_response = generate_response(client, email_data)
         
         if not draft_response:
-            print("Failed to generate a response. Skipping to next email.")
+            log("Failed to generate a response. Skipping to next email.")
             continue
         
         while True:
@@ -192,23 +185,23 @@ def process_responses():
             body = '\n'.join(response_lines[1:]).strip()
             
             # Display the draft response
-            print("\nDRAFT RESPONSE:")
-            print("-" * 50)
-            print(f"To: {email_data['email_address']}")
-            print(f"Subject: {subject_line}")
-            print("-" * 50)
-            print(body)
-            print("-" * 50)
+            log("\nDRAFT RESPONSE:")
+            log("-" * 50)
+            log(f"To: {email_data['email_address']}")
+            log(f"Subject: {subject_line}")
+            log("-" * 50)
+            log(body)
+            log("-" * 50)
             
             # Ask for confirmation
             choice = input("\nSend this response? (y/n/edit/skip): ").lower()
             
             if choice == 'y':
                 if email_data['email_address']:
-                    print(f"Sending email to {email_data['email_address']}...")
+                    log(f"Sending email to {email_data['email_address']}...")
                     result = send_email(subject_line, body, email_data['email_address'])
                     if result:
-                        print("Email sent successfully!")
+                        log("Email sent successfully!")
                         # Record this response in history
                         save_response_history({
                             "subject": email_data['subject'],
@@ -216,37 +209,37 @@ def process_responses():
                             "responded_at": datetime.now().isoformat() if 'datetime' in globals() else "2023-01-01T00:00:00"
                         })
                     else:
-                        print("Failed to send email.")
+                        log("Failed to send email.")
                 else:
-                    print("Error: No email address found for recipient.")
+                    log("Error: No email address found for recipient.")
                 break
             elif choice == 'n':
-                print("Skipping this email.")
+                log("Skipping this email.")
                 break
             elif choice == 'skip':
-                print("Marked as skipped.")
+                log("Marked as skipped.")
                 break
             elif choice == 'edit':
                 # Prompt for edit instructions
-                print("\nDescribe how you want the email rewritten:")
+                log("\nDescribe how you want the email rewritten:")
                 edit_instructions = input("> ")
                 
                 # Generate a new response based on the edit instructions
-                print("\nGenerating new response based on your instructions...")
+                log("\nGenerating new response based on your instructions...")
                 new_draft = generate_response(client, email_data, edit_instructions)
                 
                 if new_draft:
                     draft_response = new_draft
                 else:
-                    print("Failed to generate edited response. Keeping previous draft.")
+                    log("Failed to generate edited response. Keeping previous draft.")
                 
                 # Continue loop to display the new draft and prompt y/n/edit again
             else:
-                print("Invalid choice. Please enter 'y', 'n', 'edit', or 'skip'.")
+                log("Invalid choice. Please enter 'y', 'n', 'edit', or 'skip'.")
         
-        print()  # Add a blank line between emails
+        log("")  # Add a blank line between emails
     
-    print("\nAll emails processed.")
+    log("All emails processed.")
 
 if __name__ == "__main__":
     # Import datetime here to avoid circular imports 

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -1,0 +1,110 @@
+import os
+import sys
+import json
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import important_email2
+import delete_emails
+import send_mail2
+import email_responder2
+
+
+def test_group_emails_by_topics():
+    emails = [
+        {
+            "subject": "Subject A",
+            "from": "a@example.com",
+            "analysis": {
+                "topics": ["news", "updates"],
+                "importance": "low",
+                "needs_response": False
+            }
+        },
+        {
+            "subject": "Subject B",
+            "from": "b@example.com",
+            "analysis": {
+                "topics": ["news"],
+                "importance": "high",
+                "needs_response": True
+            }
+        }
+    ]
+    grouped = important_email2.group_emails_by_topics(emails)
+    assert "news" in grouped
+    assert len(grouped["news"]) == 2
+    assert any(e["subject"] == "Subject A" for e in grouped["news"])
+
+
+def test_update_delete_tasks_creates_file(tmp_path):
+    tasks_file = tmp_path / "to_delete.json"
+    email = {"subject": "Subj", "from": "test@example.com", "received": "today"}
+    analysis = important_email2.EmailImportance(
+        importance="low",
+        reason="none",
+        needs_response=False,
+        time_sensitive=False,
+        topics=[]
+    )
+    important_email2.update_delete_tasks(email, analysis, tasks_file=tasks_file)
+    assert tasks_file.exists()
+    data = json.loads(tasks_file.read_text())
+    assert data[0]["status"] == "to review"
+
+
+def test_process_deletions_marks_deleted(monkeypatch, tmp_path):
+    tasks_file = tmp_path / "to_delete.json"
+    tasks = [{"subject": "Subj", "from": "t@example.com", "status": "to delete"}]
+    tasks_file.write_text(json.dumps(tasks))
+
+    class DummyIMAP:
+        def __init__(self, server, port):
+            pass
+        def login(self, user, password):
+            pass
+        def select(self, mbox):
+            return ('OK', [b''])
+        def search(self, charset, query):
+            return ('OK', [b'1'])
+        def store(self, num, flag, val):
+            pass
+        def expunge(self):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    def dummy_imap(server, port):
+        return DummyIMAP(server, port)
+
+    monkeypatch.setattr(delete_emails.imaplib, 'IMAP4_SSL', dummy_imap)
+    monkeypatch.setenv('EMAIL_USER', 'user')
+    monkeypatch.setenv('EMAIL_PASSWORD', 'pass')
+
+    delete_emails.process_deletions(tasks_file=tasks_file)
+    data = json.loads(tasks_file.read_text())
+    assert data[0]["status"] == "deleted"
+
+
+def test_modules_use_json_output_and_logging():
+    # send_mail2 outputs
+    assert send_mail2.CATEGORIZED_EMAILS_JSON.startswith("output/")
+    assert send_mail2.CATEGORIZED_EMAILS_JSON.endswith(".json")
+    assert send_mail2.OPPORTUNITY_REPORT.startswith("output/")
+    assert send_mail2.OPPORTUNITY_REPORT.endswith(".json")
+    assert hasattr(send_mail2, "LOG_FILE")
+
+    # email_responder2 outputs
+    assert email_responder2.NEEDS_RESPONSE_REPORT.startswith("output/")
+    assert email_responder2.NEEDS_RESPONSE_REPORT.endswith(".json")
+    assert email_responder2.RESPONSE_HISTORY_FILE.startswith("output/")
+    assert email_responder2.RESPONSE_HISTORY_FILE.endswith(".json")
+    assert hasattr(email_responder2, "LOG_FILE")
+
+    # important_email2 outputs
+    assert important_email2.NEEDS_RESPONSE_JSON.startswith("output/")
+    assert important_email2.NEEDS_RESPONSE_JSON.endswith(".json")
+    assert hasattr(important_email2, "LOG_FILE")


### PR DESCRIPTION
## Summary
- add failing tests for topic grouping and deletion workflow
- add grouping by email topics and deletion task management
- save reports in `output` folder
- create `delete_emails.py` script for processing deletions
- enforce JSON outputs across all modules and ensure each script logs actions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683d87d42550832c843bd065bcb15f25